### PR TITLE
Fix generate crash when have some unknown field

### DIFF
--- a/lib/tesla/openapi/spec.ex
+++ b/lib/tesla/openapi/spec.ex
@@ -275,7 +275,7 @@ defmodule Tesla.OpenApi.Spec do
   defp models(%{"components" => _}), do: []
 
   defp models(defs) when is_map(defs) do
-    for {name, schema} <- defs do
+    for {name, schema} when is_map(schema) <- defs do
       %Model{
         name: name,
         title: schema["title"],


### PR DESCRIPTION
Found by accidentally add `$schema` to the json for autocompletion
reason. The `Tesla.OpenApi.Spec.models/1` at line 278 will crash because
of for iterate `defs` over map which's cause `schema` to be the value of
field `$schema`. Fixes by filter only schema that is map.